### PR TITLE
Improve stats performance

### DIFF
--- a/src/clean-webpack-plugin.ts
+++ b/src/clean-webpack-plugin.ts
@@ -241,6 +241,9 @@ class CleanWebpackPlugin {
         const assets: AssetInfo[] =
             stats.toJson({
                 assets: true,
+                cachedAssets: true,
+                relatedAssets: true,
+                all: false,
             }).assets || [];
 
         const relatedAssets = assets


### PR DESCRIPTION
Hey. In webpack 5 the performance of stats is particularly slow. In our application the time taken is `1.792s` without this change vs `16ms` with. This has a notable impact on rebuild times which should be fast. It could be worth getting this change in to this v5 changes PR? It may also bump the PRs test coverage up as it adds a few lines that are covered for free 😁 .